### PR TITLE
Updating error handler to use the appropriate regex

### DIFF
--- a/src/ATFParser/parserTools.js
+++ b/src/ATFParser/parserTools.js
@@ -108,7 +108,7 @@ const processError = function( error, p_name ){
 const nearlyError2Object = function(error, p_name){
 	//
 	let [keys, trees, err_lines] = nearlyErrorAnalyze(error);
-	let match = error.match(re_invalid_syntax);
+	let match = error.match(re_syntax_error);
 	let matchToken = error.match(re_error_token_data);
 	console.log('!!!!!!!!', error, match)
 	let err_obj = {


### PR DESCRIPTION
## What ##
This PR represents a small fix that appears to satisfy the problem reported in Issue #6.
  
If you look closely at the error reporting code in [`parserTools.js`](https://github.com/cdli-gh/jtf-lib/blob/main/src/ATFParser/parserTools.js), you will notice that there are [two similarly-named regex patterns](https://github.com/cdli-gh/jtf-lib/blob/main/src/ATFParser/parserTools.js#L77) for matching on error message output.
  
It turns out the function `nearlyError2Object` was expecting a specific type of error message, matching on it, and then using some of that match data to compose a new kind of error object. However, when the match fails -- as it does in the example in Issue #6 -- the program is trying to access indices of an `undefined` object.
  
## Solution ##
This PR switches to using the alternate available regex pattern instead. It's a small change, and I'm not sure how it will affect the wider code since I'm not able to get any tests to run.
  
Here is an example program I used (at the root of the repo) to verify that the new form was indeed working:
```javascript
const { ATF2JTF } = require("./src/Converters/ATF2JTF.js");

const example = `&P298489 = CBCY 03, p. 208, NBC
@seal
1. ha-ba-lu5-ge2
2. ensi2 Adab{ki}
3. ur-pa4-mu-ra
4. dub-sar
5. ARAD2-zu`;

ATF2JTF(example, '', false);
```
## Misc ##
This PR only deals with the error reporting error, and not the fact that the above example with a seal fails to parse.